### PR TITLE
HttpClient: unit tests fix

### DIFF
--- a/tests/lib/test_httpClient.py
+++ b/tests/lib/test_httpClient.py
@@ -109,7 +109,7 @@ class TestHttpClient:
 
                     def raise_for_status(self):
                         self.raise_for_status_has_no_error = False
-                        raise HTTPError('ExceptionError raised')
+                        raise Exception('ExceptionError raised')
 
                 # GIVEN
                 called_url = 'http://myapi.com'


### PR DESCRIPTION
Fix for HttpClient Unit tests, when a proper exception error should have been called.